### PR TITLE
Create Apollo.ts

### DIFF
--- a/ignition/modules/Apollo.ts
+++ b/ignition/modules/Apollo.ts
@@ -1,0 +1,9 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+
+export default buildModule("Apollo", (m) => {
+  const apollo = m.contract("Rocket", ["Saturn V"]);
+
+  m.call(apollo, "launch", []);
+
+  return { apollo };
+});


### PR DESCRIPTION
This pull request introduces a new module for the Apollo project using the Hardhat Ignition framework. The key change includes the creation of a new module that defines and launches a contract.

New module creation:

* [`ignition/modules/Apollo.ts`](diffhunk://#diff-633d98277ce0fe98c0e4fd3155afb389f2c7a24fc5c8f6c51cc9cbdc00e17c99R1-R9): Added a new module named "Apollo" which defines a contract named "Rocket" with the argument "Saturn V" and calls the "launch" method on it.